### PR TITLE
Export Sass variables as es6 modules

### DIFF
--- a/lib/exportSass.js
+++ b/lib/exportSass.js
@@ -47,7 +47,7 @@ module.exports = (outputPath) => ({
     let utilPath = path.join(outputPath, `${fileName.getValue()}.js`);
     let utilHeader = `/* eslint-disable */
 // Auto Generated file from exportSass.
-exports.default =`;
+export default `;
     let output = JSON.stringify(getOutput(value), null, " ");
 
     fs.writeFileSync(utilPath, `${utilHeader} ${output};`);


### PR DESCRIPTION
i.e. `export default {…}` vs. `exports.default = {…}`