### PR TITLE
make addon compatible with dart sass and latest ember-cli-sass versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-lts-2.16
     - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-release-node-sass
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Export Sass `$variable` values as JSON data to [Ember Utilities](https://guides.emberjs.com/v3.1.0/tutorial/service/#toc_accessing-the-google-maps-api-with-a-utility), so they can be consumed from the rest of your app. The idea is to help you step closer to an SSoT for style-related data/documentation (e.g. populating styling documentation with [Ember Freestyle](http://ember-freestyle.com/)).
 
+This addon is meant to be used with ember-cli-sass. Works with both dart sass and node-sass implementations. Check [ember-cli-sass docs](https://github.com/aexmachina/ember-cli-sass) for more information on how to provide your preferred implementation.
+
 ## Installation
 `ember i ember-cli-sass-variables-export`
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -44,6 +44,19 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-release-node-sass',
+          env: {
+            USE_NODE_SASS: true
+          },
+          npm: {
+            devDependencies: {
+              'ember-source': urls[0],
+              'sass': null,
+              'node-sass': '^4.9.3'
+            }
+          }
+        },
+        {
           name: 'ember-beta',
           npm: {
             devDependencies: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,9 +3,18 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {
-    // Add options here
-  });
+  let options = {};
+
+  if (process.env.USE_NODE_SASS) {
+    options = {
+      sassOptions: {
+        // eslint-disable-next-line node/no-extraneous-require, node/no-missing-require
+        implementation: require('node-sass')
+      }
+    };
+  }
+
+  let app = new EmberAddon(defaults, options);
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/index.js
+++ b/index.js
@@ -30,6 +30,6 @@ module.exports = {
       app.options.sassOptions.functions = {};
     }
 
-    Object.assign(app.options.sassOptions.functions, exportSass(path.join(__dirname, 'addon', 'utils')));
+    Object.assign(app.options.sassOptions.functions, exportSass(path.join(__dirname, 'addon', 'utils'), app.options.sassOptions.implementation));
   }
 };

--- a/lib/exportSass.js
+++ b/lib/exportSass.js
@@ -3,54 +3,76 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('ember-cli-sass-variables-export');
 
+let sass;
+
+// mimic the way ember-cli-sass tries to find the default sass implementation
+// only runs when no implementation was passed in
+function getDefaultSass() {
+  try {
+    return require('sass');
+  } catch (e) {
+    let error = new Error(
+      'Could not find the default SASS implementation. Run the default blueprint:\n' +
+      '   ember g ember-cli-sass\n' +
+      'Or install an implementation such as "node-sass" and add an implementation option. For example:\n' +
+      '   sassOptions: {implementation: require("node-sass")}');
+    error.type = 'Sass Plugin Error';
+
+    throw error;
+  }
+}
+
 // Based off the idea from: https://github.com/Punk-UnDeaD/node-sass-export
 const getOutput = (val) => {
   let output;
-  switch (val.constructor.name) {
-    case 'SassList':
-      output = [];
-      for (let i = 0; i < val.getLength(); i++) {
-        output.push(getOutput(val.getValue(i)));
-      }
-      debug('SassList: ', output);
-      return output;
-    case 'SassMap':
-      output = {};
-      for (let i = 0; i < val.getLength(); i++) {
-        output[val.getKey(i).getValue()] = getOutput(val.getValue(i));
-      }
-      debug('SassMap: ', output);
-      return output;
-    case 'SassColor':
-      if (val.getA() === 1) {
-        output = `rgb(${parseInt(val.getR())}, ${parseInt(val.getG())}, ${parseInt(val.getB())})`;
-      } else {
-        output = `rgba(${parseInt(val.getR())}, ${parseInt(val.getG())}, ${parseInt(val.getB())}, ${parseFloat(val.getA()).toFixed(2)})`;
-      }
-      debug('SassColor: ', output);
-      return output;
-    case 'SassNumber':
-      output = val.getValue();
-      if (val.getUnit()) {
-        output += val.getUnit();
-      }
-      debug('SassNumber: ', output);
-      return output;
-    default:
-      debug('Default:', output);
-      return val.getValue();
+
+  if (val instanceof sass.types.List) {
+    output = [];
+    for (let i = 0; i < val.getLength(); i++) {
+      output.push(getOutput(val.getValue(i)));
+    }
+    debug('List: ', output);
+  } else if (val instanceof sass.types.Map) {
+    output = {};
+    for (let i = 0; i < val.getLength(); i++) {
+      output[val.getKey(i).getValue()] = getOutput(val.getValue(i));
+    }
+    debug('Map: ', output);
+  } else if (val instanceof sass.types.Color) {
+    output;
+    if (val.getA() === 1) {
+      output = `rgb(${parseInt(val.getR())}, ${parseInt(val.getG())}, ${parseInt(val.getB())})`;
+    } else {
+      output = `rgba(${parseInt(val.getR())}, ${parseInt(val.getG())}, ${parseInt(val.getB())}, ${parseFloat(val.getA()).toFixed(2)})`;
+    }
+    debug('Color: ', output);
+  } else if (val instanceof sass.types.Number) {
+    output = val.getValue();
+    if (val.getUnit()) {
+      output += val.getUnit();
+    }
+    debug('Number: ', output);
+  } else {
+    output = val.getValue();
+    debug('Default:', output);
   }
+
+  return output;
 };
 
-module.exports = (outputPath) => ({
-  'export($fileName, $value:())': (fileName, value) => {
-    let utilPath = path.join(outputPath, `${fileName.getValue()}.js`);
-    let utilHeader = `/* eslint-disable */
+module.exports = (outputPath, implementation) => {
+  sass = implementation || getDefaultSass();
+
+  return {
+    'export($fileName, $value:())': (fileName, value) => {
+      let utilPath = path.join(outputPath, `${fileName.getValue()}.js`);
+      let utilHeader = `/* eslint-disable */
 // Auto Generated file from exportSass.
 export default `;
-    let output = JSON.stringify(getOutput(value), null, " ");
+      let output = JSON.stringify(getOutput(value), null, " ");
 
-    fs.writeFileSync(utilPath, `${utilHeader} ${output};`);
-    return value;
-  }
-});
+      fs.writeFileSync(utilPath, `${utilHeader} ${output};`);
+      return value;
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.3.2",
-    "ember-cli-sass": "^7.2.0",
+    "ember-cli-sass": "^8.0.1",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
@@ -67,7 +67,8 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^7.0.1",
     "loader.js": "^4.2.3",
-    "qunit-dom": "^0.7.1"
+    "qunit-dom": "^0.7.1",
+    "sass": "^1.13.2"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,6 +753,10 @@ async-disk-cache@^1.2.1:
     rsvp "^3.0.18"
     username-sync "1.0.1"
 
+async-each@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+
 async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
@@ -1352,6 +1356,10 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+binary-extensions@^1.0.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
+
 "binaryextensions@1 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
@@ -1426,7 +1434,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^2.3.1:
+braces@^2.3.0, braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   dependencies:
@@ -1760,14 +1768,13 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-sass-source-maps@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-sass-source-maps/-/broccoli-sass-source-maps-2.2.0.tgz#1f1a0794136152b096188638b59b42b17a4bdc68"
+broccoli-sass-source-maps@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.0.0.tgz#1ee4c10a810b10955b0502e28f85ab672f5961a2"
   dependencies:
     broccoli-caching-writer "^3.0.3"
     include-path-searcher "^0.1.0"
     mkdirp "^0.3.5"
-    node-sass "^4.7.2"
     object-assign "^2.0.0"
     rsvp "^3.0.6"
 
@@ -2012,6 +2019,25 @@ charm@^1.0.0:
   resolved "https://registry.yarnpkg.com/charm/-/charm-1.0.2.tgz#8add367153a6d9a581331052c4090991da995e35"
   dependencies:
     inherits "^2.0.1"
+
+chokidar@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.0"
+    braces "^2.3.0"
+    glob-parent "^3.1.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    lodash.debounce "^4.0.8"
+    normalize-path "^2.1.1"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
+    upath "^1.0.5"
+  optionalDependencies:
+    fsevents "^1.2.2"
 
 chownr@^1.0.1:
   version "1.0.1"
@@ -2653,13 +2679,13 @@ ember-cli-qunit@^4.3.2:
     ember-cli-babel "^6.11.0"
     ember-qunit "^3.3.2"
 
-ember-cli-sass@^7.2.0:
-  version "7.2.0"
-  resolved "http://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-7.2.0.tgz#293d1a94c43c1fdbb3835378e43d255e8ad5c961"
+ember-cli-sass@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-sass/-/ember-cli-sass-8.0.1.tgz#22730bb8eee1eedc6ddd0cf2e51f5405a09b9139"
   dependencies:
     broccoli-funnel "^1.0.0"
     broccoli-merge-trees "^1.1.0"
-    broccoli-sass-source-maps "^2.1.0"
+    broccoli-sass-source-maps "^4.0.0"
     ember-cli-version-checker "^2.1.0"
 
 ember-cli-shims@^1.2.0:
@@ -3523,7 +3549,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.2.3:
+fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
@@ -3633,6 +3659,13 @@ git-write-pkt-line@0.1.0:
   dependencies:
     bops "0.0.3"
     through "~2.2.7"
+
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
 
 glob@^5.0.10:
   version "5.0.15"
@@ -4081,6 +4114,12 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+is-binary-path@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
+  dependencies:
+    binary-extensions "^1.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -4129,7 +4168,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.0:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
@@ -4158,6 +4197,12 @@ is-glob@^3.1.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   dependencies:
     is-extglob "^2.1.0"
+
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -4653,6 +4698,10 @@ lodash.debounce@^3.1.1:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
   dependencies:
     lodash._getnative "^3.0.0"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
 lodash.defaults@~2.3.0:
   version "2.3.0"
@@ -5199,7 +5248,7 @@ node-releases@^1.0.0-alpha.11:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.7.2:
+node-sass@^4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.3.tgz#f407cf3d66f78308bb1e346b24fa428703196224"
   dependencies:
@@ -5497,6 +5546,10 @@ passwd-user@^1.2.1:
   dependencies:
     exec-file-sync "^2.0.0"
 
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -5736,7 +5789,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -5756,6 +5809,15 @@ readable-stream@~1.0.2:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readdirp@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
+  dependencies:
+    graceful-fs "^4.1.2"
+    minimatch "^3.0.2"
+    readable-stream "^2.0.2"
+    set-immediate-shim "^1.0.1"
 
 recast@^0.11.3:
   version "0.11.23"
@@ -6125,6 +6187,12 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
+sass@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.13.2.tgz#e4c43cf3cc9e8451960831dc66a5b76a3b038024"
+  dependencies:
+    chokidar "^2.0.0"
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -6174,6 +6242,10 @@ serve-static@1.13.2:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-immediate-shim@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
 set-value@^0.4.3:
   version "0.4.3"
@@ -6898,6 +6970,10 @@ untildify@^2.1.0:
 unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+
+upath@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR rewrites the export function to be compatible with dart sass and not just node-sass.

Also added an ember-try scenario with ember release, *no* dart sass and node-sass to make sure we're testing against both implementations.