### PR TITLE
make it ember-cli-sass 7.2.0 compatible

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,8 @@ module.exports = {
         'testem.js',
         'blueprints/*/index.js',
         'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'tests/dummy/config/**/*.js',
+        'lib/**/*.js'
       ],
       excludedFiles: [
         'addon/**',

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-release-node-sass
+    - EMBER_TRY_SCENARIO=ember-release-with-old-ember-cli-sass
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -57,6 +57,17 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-release-with-old-ember-cli-sass',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[0],
+              'ember-cli-sass': '^7.2.0',
+              'sass': null,
+              'node-sass': null
+            }
+          }
+        },
+        {
           name: 'ember-beta',
           npm: {
             devDependencies: {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,23 @@
 'use strict';
 const exportSass = require('./lib/exportSass');
 const path = require('path');
+const VersionChecker = require('ember-cli-version-checker');
+
+function getDefaultSass() {
+  try {
+    // eslint-disable-next-line node/no-extraneous-require, node/no-missing-require node/no-unpublished-require
+    return require('sass');
+  } catch (e) {
+    let error = new Error(
+      'Could not find the default SASS implementation. Run the default blueprint:\n' +
+      '   ember g ember-cli-sass\n' +
+      'Or install an implementation such as "node-sass" and add an implementation option. For example:\n' +
+      '   sassOptions: {implementation: require("node-sass")}');
+    error.type = 'Sass Plugin Error';
+
+    throw error;
+  }
+}
 
 module.exports = {
   name: 'ember-cli-sass-variables-export',
@@ -30,6 +47,23 @@ module.exports = {
       app.options.sassOptions.functions = {};
     }
 
-    Object.assign(app.options.sassOptions.functions, exportSass(path.join(__dirname, 'addon', 'utils'), app.options.sassOptions.implementation));
+    let checker = new VersionChecker(this);
+    let sass = checker.for('ember-cli-sass');
+
+    let implementation = app.options.sassOptions.implementation;
+
+    if (sass.lt('8.0.0')) {
+      // these ember-cli-sass versions used node-sass by default
+      // so we force its usage
+      // eslint-disable-next-line node/no-extraneous-require, node/no-missing-require
+      implementation = require('node-sass');
+    } else {
+      // on ember-cli-sass version8 and above
+      // we mimic the way ember-cli-sass tries to find the default sass implementation
+      // only runs when no implementation was passed in
+      implementation = implementation || getDefaultSass();
+    }
+
+    Object.assign(app.options.sassOptions.functions, exportSass(path.join(__dirname, 'addon', 'utils'), implementation));
   }
 };

--- a/lib/exportSass.js
+++ b/lib/exportSass.js
@@ -1,26 +1,9 @@
-/* eslint-env node */
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
-const debug = require('debug')('ember-cli-sass-variables-export');
 
 let sass;
-
-// mimic the way ember-cli-sass tries to find the default sass implementation
-// only runs when no implementation was passed in
-function getDefaultSass() {
-  try {
-    return require('sass');
-  } catch (e) {
-    let error = new Error(
-      'Could not find the default SASS implementation. Run the default blueprint:\n' +
-      '   ember g ember-cli-sass\n' +
-      'Or install an implementation such as "node-sass" and add an implementation option. For example:\n' +
-      '   sassOptions: {implementation: require("node-sass")}');
-    error.type = 'Sass Plugin Error';
-
-    throw error;
-  }
-}
 
 // Based off the idea from: https://github.com/Punk-UnDeaD/node-sass-export
 const getOutput = (val) => {
@@ -31,13 +14,11 @@ const getOutput = (val) => {
     for (let i = 0; i < val.getLength(); i++) {
       output.push(getOutput(val.getValue(i)));
     }
-    debug('List: ', output);
   } else if (val instanceof sass.types.Map) {
     output = {};
     for (let i = 0; i < val.getLength(); i++) {
       output[val.getKey(i).getValue()] = getOutput(val.getValue(i));
     }
-    debug('Map: ', output);
   } else if (val instanceof sass.types.Color) {
     output;
     if (val.getA() === 1) {
@@ -45,23 +26,20 @@ const getOutput = (val) => {
     } else {
       output = `rgba(${parseInt(val.getR())}, ${parseInt(val.getG())}, ${parseInt(val.getB())}, ${parseFloat(val.getA()).toFixed(2)})`;
     }
-    debug('Color: ', output);
   } else if (val instanceof sass.types.Number) {
     output = val.getValue();
     if (val.getUnit()) {
       output += val.getUnit();
     }
-    debug('Number: ', output);
   } else {
     output = val.getValue();
-    debug('Default:', output);
   }
 
   return output;
 };
 
 module.exports = (outputPath, implementation) => {
-  sass = implementation || getDefaultSass();
+  sass = implementation;
 
   return {
     'export($fileName, $value:())': (fileName, value) => {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "postversion": "git push --follow-tags"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.1.0"
+    "ember-cli-babel": "^7.1.0",
+    "ember-cli-version-checker": "^2.1.2"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
using the addon with ember-cli-sass 7.2.0 (and below) was breaking because it expected dart sass to be installed.
That behavior only applies to ember-cli-sass 8.0.0 and above.

Also added an ember-try scenario to test this.